### PR TITLE
fix: Render Drupal markup without hydrating its innerHTML.

### DIFF
--- a/components/global/drupal-markup.vue
+++ b/components/global/drupal-markup.vue
@@ -1,6 +1,6 @@
 <template>
   <slot />
-  <div v-if="content" style="display: contents" v-html="content" />
+  <div v-if="content" v-drupal-markup="content" style="display: contents" />
 </template>
 
 <script setup lang="ts">
@@ -19,6 +19,9 @@ defineProps<{
 
 // Using display:contents makes this div virtually invisible in the layout
 // This mitigates the impact of the wrapping div when rendering the content.
+// The markup is applied with v-drupal-markup rather than v-html so that
+// hydration adopts the server-rendered DOM instead of recreating it - see the
+// directive in nuxtjs-drupal-ce for what that protects.
 defineSlots<{
   default(): any
 }>()


### PR DESCRIPTION
Sibling of **drunomics/nuxtjs-drupal-ce#515** — see that PR for the full analysis.

## Problem

`v-html` binds `innerHTML`, and since **vue 3.5.39** hydration re-applies a vnode's bound props over the live DOM ([vuejs/core#15138](https://github.com/vuejs/core/issues/15138), closed as intended behavior) — recreating every child node of the markup wrapper. Text a visitor typed into a Drupal-rendered form field before hydration completes is silently discarded, and the form then posts empty. Script-driven DOM changes inside the markup (lazyload swaps, Drupal behaviors) are reverted too.

`components/global/drupal-markup.vue` renders every CE markup string — including Drupal form markup — through `v-html`, so the starter is affected. Verified with a jsdom SSR → type → hydrate harness against this exact file: vue 3.5.38 keeps the typed value and the DOM node, **vue 3.5.40 wipes both**.

This is not gated on nuxt 4.5 — nuxt 4.4 already accepts `vue ^3.5.30`. `package-lock.json` currently pins vue 3.5.32, which is the only thing holding it back; any lockfile refresh pulls the affected version.

## Change

One attribute: `v-html` → `v-drupal-markup`, the directive nuxtjs-drupal-ce registers app-wide. It emits `innerHTML` during SSR only, so hydration adopts the server DOM untouched; client-side mounts and genuine content changes keep behaving exactly like `v-html`.

## Merge order

**Must land after a nuxtjs-drupal-ce release containing the directive** (drunomics/nuxtjs-drupal-ce#515). Without it, `v-drupal-markup` does not resolve and the markup would not render. `nuxtjs-drupal-ce` is a caret dependency here (`^2.6.1`), so a patch/minor release is picked up automatically — no version bump needed in this PR, though pinning the minimum would be reasonable if you prefer an explicit guard.

Note that the module PR also routes markup strings through this component's default slot, which fixes string content even without this change. This edit covers the legacy JSON format (`{element: 'drupal-markup', content: '…'}`), which passes markup as a prop and still renders through the component's own template.

## Verification

Covered by the module PR's test suite (98/98), including the same hydration assertion run against this component's source. Not separately re-run here — this file is byte-identical to the scaffold shipped by the module.

## Notes

Drafted with assistance from Claude Code in the loki dev VM, supervised by @fago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
